### PR TITLE
Fix bugged button background color when enabled/disabled

### DIFF
--- a/PolyDice2/MainPage.xaml.cs
+++ b/PolyDice2/MainPage.xaml.cs
@@ -24,7 +24,9 @@ public partial class MainPage : ContentPage
         set {
             _die = value;
             OnPropertyChanged();
+            OnPropertyChanged(nameof(EnableControls));
             OnPropertyChanged(nameof(ShowAdvancedOptions));
+            OnPropertyChanged(nameof(EnableCountLessBtn));
         }
     }
 
@@ -70,10 +72,10 @@ public partial class MainPage : ContentPage
     }
 
     public MainPage()
-	{
+    {
+        BindingContext = this;
         CurrentDie = new Die(20);
         InitializeComponent();
-        BindingContext = this;
     }
 
 	private void OnRollClicked(object sender, EventArgs e)

--- a/PolyDice2/Resources/Styles/Style.xaml
+++ b/PolyDice2/Resources/Styles/Style.xaml
@@ -6,6 +6,8 @@
     <Color x:Key="GreyLight">#7F7F7F</Color>
     <Color x:Key="GreyMid">#5D5D5D</Color>
     <Color x:Key="GreyDark">#2B2B2B</Color>
+    <SolidColorBrush x:Key="GreyMidBrush" Color="{StaticResource GreyMid}" />
+    <SolidColorBrush x:Key="GreyLightBrush" Color="{StaticResource GreyLight}" />
 
     <Style TargetType="Page" ApplyToDerivedTypes="True">
         <Setter Property="BackgroundColor" Value="{StaticResource GreyDark}" />
@@ -30,7 +32,7 @@
     
     <Style TargetType="Button">
         <Setter Property="TextColor" Value="{StaticResource GreyDark}" />
-        <Setter Property="BackgroundColor" Value="{StaticResource GreyLight}" />
+        <Setter Property="Background" Value="{StaticResource GreyLightBrush}" />
         <Setter Property="FontAttributes" Value="Bold" />
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
@@ -38,7 +40,7 @@
                     <VisualState x:Name="Normal" />
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
-                            <Setter Property="BackgroundColor" Value="{StaticResource GreyMid}" />
+                            <Setter Property="Background" Value="{StaticResource GreyMidBrush}" />
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>


### PR DESCRIPTION
Applied workaround (use Background property with a brush instead of BackgroundColor) mentioned in this issue: https://github.com/dotnet/maui/issues/11662